### PR TITLE
Removing activemodel dependency

### DIFF
--- a/mongoid-paranoia.gemspec
+++ b/mongoid-paranoia.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activemodel", ['~> 4.0.0']
   gem.add_dependency "mongoid", '> 3'
 end


### PR DESCRIPTION
I think you don't need activemodel directly since it's mongoid's dependency.
It also prevents me from using the gem with rails 4.1.0 which is now rc1.
