### PR TITLE
Added 'removal' callbacks that run exclusively on permanent removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Person.unscoped.all # Returns all documents, both deleted and non-deleted
 
 ### Callbacks
 
-`before_restore`, `after_restore` and `around_restore` callbacks are added to your model. They work similarly to the `before_destroy`, `after_destroy` and `around_destroy` callbacks.
+`before_restore`, `after_restore` and `around_restore` callbacks are added to your model. They work similarly to the `before_destroy`, `after_destroy` and `around_destroy` callbacks. Also `before_remove`, `after_remove` and `around_remove` are added, they are only called when permanently deleting a record.
 
 ```ruby
 class User

--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -25,6 +25,7 @@ module Mongoid
       default_scope -> { where(deleted_at: nil) }
       scope :deleted, -> { ne(deleted_at: nil) }
       define_model_callbacks :restore
+      define_model_callbacks :remove
     end
 
     # Delete the paranoid +Document+ from the database completely. This will
@@ -37,7 +38,11 @@ module Mongoid
     #
     # @since 1.0.0
     def destroy!
-      run_callbacks(:destroy) { delete! }
+      run_callbacks(:destroy) do
+        run_callbacks(:remove) do
+          delete!
+        end
+      end
     end
 
     # Override the persisted method to allow for the paranoia gem.

--- a/spec/app/models/paranoid_post.rb
+++ b/spec/app/models/paranoid_post.rb
@@ -6,6 +6,7 @@ class ParanoidPost
 
   attr_accessor :after_destroy_called, :before_destroy_called,
                 :after_restore_called, :before_restore_called,
+                :after_remove_called, :before_remove_called,
                 :around_before_restore_called, :around_after_restore_called
 
   belongs_to :person
@@ -19,6 +20,9 @@ class ParanoidPost
   before_destroy :before_destroy_stub
   after_destroy  :after_destroy_stub
 
+  before_remove :before_remove_stub
+  after_remove  :after_remove_stub
+
   before_restore :before_restore_stub
   after_restore  :after_restore_stub
   around_restore :around_restore_stub
@@ -29,6 +33,14 @@ class ParanoidPost
 
   def after_destroy_stub
     self.after_destroy_called = true
+  end
+
+  def before_remove_stub
+    self.before_remove_called = true
+  end
+
+  def after_remove_stub
+    self.after_remove_called = true
   end
 
   def before_restore_stub

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -82,6 +82,14 @@ describe Mongoid::Paranoia do
       it "executes the after destroy callbacks" do
         expect(post.after_destroy_called).to be_truthy
       end
+
+      it "executes the before remove callbacks" do
+        expect(post.before_remove_called).to be_truthy
+      end
+
+      it "executes the after remove callbacks" do
+        expect(post.after_remove_called).to be_truthy
+      end
     end
 
     context "when the document is embedded" do
@@ -173,6 +181,14 @@ describe Mongoid::Paranoia do
 
       it "executes the after destroy callbacks" do
         expect(post.after_destroy_called).to be_truthy
+      end
+
+      it "does not execute the before remove callbacks" do
+        expect(post.before_remove_called).to be_falsey
+      end
+
+      it "does not execute the after remove callbacks" do
+        expect(post.after_remove_called).to be_falsey
       end
     end
 


### PR DESCRIPTION
Hey,

I needed a callback that ran exclusively when the document gets "hard" removed so I created one. I didn't have a great name for it so I called it removal. Please take a look and tell me your thoughts. If everything is ok I will be happy to update docs including this.