### PR TITLE
Fix callback in a dummy application used in specs

### DIFF
--- a/spec/app/models/paranoid_phone.rb
+++ b/spec/app/models/paranoid_phone.rb
@@ -20,6 +20,6 @@ class ParanoidPhone
   end
 
   def halt_me
-    person.age == 42 ? false : true
+    throw :abort if person.age == 42
   end
 end


### PR DESCRIPTION
Rails 5 has changed the way how callbacks chain should be stopped. Returning false no longer works.  Now one should throw an `:abort` symbol.

Unfortunately, tests were passing despite of the obvious incompatibility with newest Rails. Only deprecation warning was displayed, and this pull request fixes that warning. Tests should be improved, but that's another story and probably it's not limited to this issue.

The test which has been affected is `Mongoid::Attributes::Nested#RSpec::ExampleGroups::MongoidAttributesNested_attributes= when the parent document is new when the relation is an embeds many when ids are passed when destroy attributes are passed when the ids match when allow_destroy is true when the child has defaults when the parent is persisted when the child returns false in a before callback when the child is paranoid does not destroy the child` (`spec/mongoid/nested_attributes_spec.rb:146`).

One of the possible ways to cause that spec to fail prior this fix is to add to the spec helper:
```
ActiveSupport::Deprecation.behavior = Proc.new { |message, callstack|
  raise message + "\n" + callstack.join("\n  ")
}
```