### PR TITLE
Fix to define alias :remove before definition

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -94,8 +94,7 @@ module Mongoid
     # @return [ true ] True.
     #
     # @since 1.0.0
-    alias orig_remove :remove
-
+    
     def remove(_ = {})
       cascade!
       time = self.deleted_at = Time.now
@@ -103,6 +102,7 @@ module Mongoid
       @destroyed = true
       true
     end
+    alias orig_remove :remove
 
     alias delete :remove
 


### PR DESCRIPTION
rspec tests fail because eager loading is not turned on by default 
undefined method `remove' for module `Mongoid::Paranoia' (NameError)
```
def foo
  "foo"
end

alias :baz, :foo
```
Loading the method before alias removes the dependency of eager loading the entire gem. 
