### PR TITLE
Test against latest Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
-sudo: false
+
 rvm:
   - 2.3.8
   - 2.4.6
   - 2.5.5
-  - 2.6.2
-  - jruby-9.2.6.0
+  - 2.6.3
+  - jruby-9.2.7.0
 
 env:
   global:


### PR DESCRIPTION
- Ruby 2.6.3
- JRuby 9.2.7.0

Also removes obsolete sudo option.

Ref: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration