### PR TITLE
fix undefined method `apply_delete_dependencies!` with mongoid 7.3 

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -97,7 +97,11 @@ module Mongoid
     alias orig_remove :remove
 
     def remove(_ = {})
-      return false unless catch(:abort) { apply_delete_dependencies! }
+      if Mongoid::VERSION >= "7.3.0"
+        return false unless catch(:abort) { apply_destroy_dependencies! }
+      else
+        return false unless catch(:abort) { apply_delete_dependencies! }
+      end
       time = self.deleted_at = Time.now
       _paranoia_update('$set' => { paranoid_field => time })
       @destroyed = true


### PR DESCRIPTION
mongoid 7.3 rename  `apply_delete_dependencies` to `apply_destroy_dependencies` https://github.com/mongodb/mongoid/pull/4962/files