### PR TITLE
Support only Mongoid 7.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0 (2021/07/24)
+
+* Support only Mongoid 7.3 and later.
+* In conformity with Mongoid 7.3+ behavior, dependencies are not destroyed when calling delete/delete!
+
 ## 0.4.1 (2021/07/24)
 
 * Do not allow Mongoid 7.3 and later, due to breaking changes

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec name: 'mongoid_paranoia'
 
-gem 'mongoid', '~> 7.0'
+gem 'mongoid', '~> 7.3'
 
 group :test do
   gem 'rspec', '~> 3.8'

--- a/lib/mongoid/paranoia/version.rb
+++ b/lib/mongoid/paranoia/version.rb
@@ -2,6 +2,6 @@
 
 module Mongoid
   module Paranoia
-    VERSION = '0.4.1'
+    VERSION = '0.5.0'
   end
 end

--- a/mongoid_paranoia.gemspec
+++ b/mongoid_paranoia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{perf,spec}/**/*')
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mongoid', '>= 7.0', '< 7.3'
+  gem.add_dependency 'mongoid', '~> 7.3'
 
   gem.add_development_dependency 'rubocop', '>= 1.8.1'
 end

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -531,10 +531,10 @@ describe Mongoid::Paranoia do
         post.delete!
       end
 
-      it "cascades the dependent option" do
+      it "does not cascade the dependent option" do
         expect {
           author.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to_not raise_error(Mongoid::Errors::DocumentNotFound)
       end
     end
   end
@@ -613,10 +613,10 @@ describe Mongoid::Paranoia do
         post.delete
       end
 
-      it "cascades the dependent option" do
+      it "does not cascade the dependent option" do
         expect {
           author.reload
-        }.to raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to_not raise_error(Mongoid::Errors::DocumentNotFound)
       end
     end
 
@@ -637,8 +637,8 @@ describe Mongoid::Paranoia do
         end
       end
 
-      it "does not destroy the document" do
-        expect(post).not_to be_destroyed
+      it "ignores restrict and destroys the document" do
+        expect(post).to be_destroyed
       end
     end
   end


### PR DESCRIPTION
In conformity with Mongoid 7.3+ behavior, dependencies are not destroyed when calling delete/delete!
