### PR TITLE
Mongoid 8.x.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.6.0 (2023/01/09)
 
-* Now supports mongoid 7.3 to 8.0.x versions.
+* Now supports mongoid 7.3 to 8.x.x versions.
 
 ## 0.5.0 (2021/07/24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0 (2023/01/09)
+
+* Now supports mongoid 7.3 to 8.0.x versions.
+
 ## 0.5.0 (2021/07/24)
 
 * Support only Mongoid 7.3 and later.

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec name: 'mongoid_paranoia'
 
-gem 'mongoid', '~> 8.0.3'
+gem 'mongoid', '~> 8.1'
 
 group :test do
   gem 'rspec', '~> 3.8'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec name: 'mongoid_paranoia'
 
-gem 'mongoid', '~> 7.3'
+gem 'mongoid', '~> 8.0.3'
 
 group :test do
   gem 'rspec', '~> 3.8'

--- a/lib/mongoid/paranoia/version.rb
+++ b/lib/mongoid/paranoia/version.rb
@@ -2,6 +2,6 @@
 
 module Mongoid
   module Paranoia
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'
   end
 end

--- a/mongoid_paranoia.gemspec
+++ b/mongoid_paranoia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{perf,spec}/**/*')
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mongoid', '~> 7.3'
+  gem.add_dependency 'mongoid', '~> 8.0.3'
 
   gem.add_development_dependency 'rubocop', '>= 1.8.1'
 end

--- a/mongoid_paranoia.gemspec
+++ b/mongoid_paranoia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{perf,spec}/**/*')
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mongoid', '< 8.1', '>= 7.3'
+  gem.add_dependency 'mongoid', '< 9', '>= 7.3'
 
   gem.add_development_dependency 'rubocop', '>= 1.8.1'
 end

--- a/mongoid_paranoia.gemspec
+++ b/mongoid_paranoia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{perf,spec}/**/*')
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mongoid', '~> 8.0'
+  gem.add_dependency 'mongoid', '< 8.1', '>= 7.3'
 
   gem.add_development_dependency 'rubocop', '>= 1.8.1'
 end

--- a/mongoid_paranoia.gemspec
+++ b/mongoid_paranoia.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir.glob('{perf,spec}/**/*')
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mongoid', '~> 8.0.3'
+  gem.add_dependency 'mongoid', '~> 8.0'
 
   gem.add_development_dependency 'rubocop', '>= 1.8.1'
 end

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -534,7 +534,7 @@ describe Mongoid::Paranoia do
       it "does not cascade the dependent option" do
         expect {
           author.reload
-        }.to_not raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to_not raise_error
       end
     end
   end
@@ -616,7 +616,7 @@ describe Mongoid::Paranoia do
       it "does not cascade the dependent option" do
         expect {
           author.reload
-        }.to_not raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
Mongoid has released the mongoid 8 version. hence this PR adds support for mongoid 8.0.x versions for the gem.

No breaking changes related to deletion in mongoid 8 [changelog](https://www.mongodb.com/docs/mongoid/current/release-notes/mongoid-8.0/)

Tests are passing without an issue.
<img width="1054" alt="image" src="https://user-images.githubusercontent.com/44117822/211309198-3cd125f7-ba53-42dd-9ffa-02b76f8f4b07.png">
Note: Two tests were updated due to Rspec warnings.