### PR TITLE
Mongoid 8 support + gardening

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,22 @@
+---
+name: Rubocop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      TESTOPTS: '-v'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby 3.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - name: bundle install
+        run: bundle install --jobs 4 --retry 3
+      - name: Run Rubocop
+        run: bundle exec rubocop --parallel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0, jruby, truffleruby]
+        ruby: [2.7, 3.0, 3.1, 3.2, jruby, truffleruby]
+        mongoid: [7, 8]
         experimental: [false]
         include:
           - ruby: head
@@ -42,8 +43,12 @@ jobs:
 
       - name: bundle install
         run:  bundle install --jobs 4 --retry 3
+        env:
+          MONGOID_VERSION: ${{ matrix.mongoid }}
 
       - name: test
         timeout-minutes: 10
         run: bundle exec rake spec
         continue-on-error: ${{ matrix.experimental }}
+        env:
+          MONGOID_VERSION: ${{ matrix.mongoid }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         ruby: [2.7, 3.0, 3.1, 3.2, jruby, truffleruby]
         mongoid: [7, 8]
         experimental: [false]
         include:
           - ruby: head
+            mongoid: head
             experimental: true
           - ruby: jruby-head
+            mongoid: 8
             experimental: true
           - ruby: truffleruby-head
+            mongoid: 8
             experimental: true
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2, jruby, truffleruby]
+        ruby: [2.7, 3.0, 3.1, 3.2, truffleruby]
         mongoid: [7, 8]
         experimental: [false]
         include:
           - ruby: head
             mongoid: head
+            experimental: true
+          - ruby: jruby-head
+            mongoid: 8
+            experimental: true
+          - ruby: jruby
+            mongoid: 7
+            experimental: true
+          - ruby: jruby
+            mongoid: 8
             experimental: true
           - ruby: jruby-head
             mongoid: 8

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   NewCops: enable
   SuggestExtensions: false
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - spec/**/*
     - vendor/**/*
@@ -19,7 +19,7 @@ Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
 Layout/IndentationWidth:
-  IgnoredPatterns:
+  AllowedPatterns:
     - '^\s*module'
 
 Layout/LineLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.0 (2023/09/18)
+
+* Loosen version support requirement to include Mongoid 7.3, 8.0, and above.
+* Add Rubocop to CI.
+* Fix minor Rubocop issues.
+* Drop support for Ruby < 2.7.
+
 ## 0.5.0 (2021/07/24)
 
 * Support only Mongoid 7.3 and later.
@@ -5,31 +12,31 @@
 
 ## 0.4.1 (2021/07/24)
 
-* Do not allow Mongoid 7.3 and later, due to breaking changes
-* Switch to Github Actions from Travis CI
-* Add Rubocop and fix issues
-* Dropped Ruby < 2.4
+* Do not allow Mongoid 7.3 and later, due to breaking changes.
+* Switch to Github Actions from Travis CI.
+* Add Rubocop and fix issues.
+* Drop support for Ruby < 2.4.
 
 ## 0.4.0 (2019/05/29)
 
-* Mongoid 7.0 support
-* Drop Mongoid 6 and Ruby < 2.3
+* Mongoid 7.0 support.
+* Drop support for Mongoid 6 and Ruby < 2.3.
 
 ## 0.3.0 (2017/01/05)
 
-* Mongoid 6.0 support
-* Drop Mongoid 4/5 and Ruby < 2.2.2
+* Mongoid 6.0 support.
+* Drop support for Mongoid 4/5 and Ruby < 2.2.2.
 
 ## 0.2.1 (2015/09/28)
 
-* [#40](https://github.com/simi/mongoid_paranoia/pull/40): Don't override mongoid original update - [@simi](https://github.com/simi).
+* [#40](https://github.com/simi/mongoid_paranoia/pull/40): Don't override mongoid original update - [@simi](https://github.com/simi)
 
 ## 0.2.0 (2015/09/22)
 
-* [#38](https://github.com/simi/mongoid_paranoia/pull/38): Added support for Mongoid 5 - [@dblock](https://github.com/dblock).
-* [#29](https://github.com/simi/mongoid_paranoia/pull/29): Added `before_remove`, `after_remove` and `around_remove` callbacks - [@marcelloma](https://github.com/marcelloma).
-* [#34](https://github.com/simi/mongoid_paranoia/pull/34): Allow configuring of the paranoid field naming on a global basis - [@ak47](https://github.com/ak47).
+* [#38](https://github.com/simi/mongoid_paranoia/pull/38): Added support for Mongoid 5 - [@dblock](https://github.com/dblock)
+* [#29](https://github.com/simi/mongoid_paranoia/pull/29): Added `before_remove`, `after_remove` and `around_remove` callbacks - [@marcelloma](https://github.com/marcelloma)
+* [#34](https://github.com/simi/mongoid_paranoia/pull/34): Allow configuring of the paranoid field naming on a global basis - [@ak47](https://github.com/ak47)
 
 ## 0.1.2 (2014/07/11)
 
-* Initial public release - [@simi](https://github.com/simi).
+* Initial public release - [@simi](https://github.com/simi)

--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,15 @@
 source 'https://rubygems.org'
 gemspec name: 'mongoid_paranoia'
 
-gem 'mongoid', '~> 7.3'
-
-group :test do
-  gem 'rspec', '~> 3.8'
+case (version = ENV['MONGOID_VERSION'] || '8')
+when 'HEAD'
+  gem 'mongoid', github: 'mongodb/mongoid'
+when /\A\d+\z/
+  gem 'mongoid', "~> #{version}.0"
+else
+  gem 'mongoid', version
 end
 
-group :development do
-  gem 'rake'
-end
+gem 'rake'
+gem 'rspec'
+gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 gemspec name: 'mongoid_paranoia'
 
 case (version = ENV['MONGOID_VERSION'] || '8')
-when 'HEAD'
+when /\Ahead\z/i
   gem 'mongoid', github: 'mongodb/mongoid'
 when /\A\d+\z/
   gem 'mongoid', "~> #{version}.0"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Paranoid Documents for Mongoid
 [![Build Status](https://travis-ci.org/simi/mongoid_paranoia.svg?branch=master)](https://travis-ci.org/simi/mongoid_paranoia) [![Gem Version](https://img.shields.io/gem/v/mongoid_paranoia.svg)](https://rubygems.org/gems/mongoid_paranoia) [![Gitter chat](https://badges.gitter.im/simi/mongoid_paranoia.svg)](https://gitter.im/simi/mongoid_paranoia)
 
-`Mongoid::Paranoia` enables a "soft delete" of Mongoid documents. Instead of being removed from the database, paranoid docs are flagged with a `deleted_at` timestamp and are ignored from queries by default.
+`Mongoid::Paranoia` enables a "soft delete" of Mongoid documents.
+Instead of being removed from the database, paranoid docs are flagged
+with a `deleted_at` timestamp and are ignored from queries by default.
 
-The `Mongoid::Paranoia` functionality was originally supported in Mongoid itself, but was dropped from version 4.0.0 onwards. This gem was extracted from the [Mongoid 3.0.0-stable branch](https://github.com/mongoid/mongoid/tree/3.0.0-stable). This gem should not be used with Mongoid versions 3.x and prior. Current master branch targeted on Mongoid 6.0. With release 0.3.0 Mongoid 4 and 5 versions will be dropped.
+The `Mongoid::Paranoia` functionality was originally supported in Mongoid
+itself, but was dropped from version 4.0 onwards. This gem was extracted
+from the [Mongoid 3.0.0-stable branch](https://github.com/mongodb/mongoid/tree/3.0.0-stable).
 
 **Caution:** This repo/gem `mongoid_paranoia` (underscored) is different than [mongoid-paranoia](https://github.com/haihappen/mongoid-paranoia) (hyphenated). The goal of `mongoid-paranoia` (hyphenated) is to stay API compatible and it only accepts security fixes.
+
+## Version Support
+
+* The current release is compatible with Mongoid 7.3 and later, and Ruby 2.7 and later.
+* Earlier Mongoid and Ruby versions are supported on earlier releases.
 
 ## Installation
 

--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -75,7 +75,7 @@ module Mongoid
     # @return [ true ] True.
     #
     # @since 1.0.0
-    alias :orig_delete :delete
+    alias orig_delete delete
 
     def remove(_ = {})
       time = self.deleted_at = Time.now
@@ -84,8 +84,8 @@ module Mongoid
       true
     end
 
-    alias :delete :remove
-    alias :delete! :orig_delete
+    alias delete remove
+    alias delete! orig_delete
 
     # Delete the paranoid +Document+ from the database completely. This will
     # run the destroy and remove callbacks.

--- a/lib/mongoid/paranoia/version.rb
+++ b/lib/mongoid/paranoia/version.rb
@@ -2,6 +2,6 @@
 
 module Mongoid
   module Paranoia
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'
   end
 end

--- a/mongoid_paranoia.gemspec
+++ b/mongoid_paranoia.gemspec
@@ -14,10 +14,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.files         = Dir.glob('lib/**/*') + %w[LICENSE README.md]
-  gem.test_files    = Dir.glob('{perf,spec}/**/*')
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'mongoid', '~> 7.3'
-
-  gem.add_development_dependency 'rubocop', '>= 1.8.1'
+  gem.add_dependency 'mongoid', '>= 7.3'
+  gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/perf/scope.rb
+++ b/perf/scope.rb
@@ -35,7 +35,7 @@ end
 
 if ENV['FORCE']
   Mongoid.purge!
-  ::Mongoid::Tasks::Database.create_indexes
+  Mongoid::Tasks::Database.create_indexes
 
   n = 50_000
   n.times {|i| Model.create(text: "text #{i}") }


### PR DESCRIPTION
- Loosen version support requirement to include Mongoid 7.3, 8.0, and above.
- Add Rubocop to CI.
- Fix minor Rubocop issues.
- Dropped Ruby < 2.7.