### PR TITLE
Fix #destroy hanging after another action inside a transaction

### DIFF
--- a/lib/mongoid/paranoia.rb
+++ b/lib/mongoid/paranoia.rb
@@ -190,7 +190,7 @@ module Mongoid
     # @return [ Object ] Update result.
     #
     def _paranoia_update(value)
-      paranoid_collection.find(atomic_selector).update_one(value)
+      paranoid_collection.find(atomic_selector).update_one(value, session: _session)
     end
   end
 end

--- a/spec/mongoid/paranoia_spec.rb
+++ b/spec/mongoid/paranoia_spec.rb
@@ -318,6 +318,27 @@ describe Mongoid::Paranoia do
         expect(post).not_to be_destroyed
       end
     end
+
+    context "when multiple operations wrapped inside transaction" do
+
+      let(:post) do
+        ParanoidPost.create(title: "test")
+      end
+
+      before do
+        post.with_session do |session|
+          session.with_transaction(write_concern: {w: :majority}) do
+            post.set(title: "test_new")
+            post.destroy
+          end
+        end
+      end
+
+      it "should perform operations correct and commit result" do
+        expect(post.title).to eq("test_new")
+        expect(post).to be_destroyed
+      end
+    end
   end
 
   describe "#destroyed?" do


### PR DESCRIPTION
Related issue: #73 