### PR TITLE
Don't soft-destroy nested records before save

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,4 @@ end
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'
+gem 'ostruct'

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ else
   gem 'mongoid', version
 end
 
+gem 'ostruct'
 gem 'rake'
 gem 'rspec'
 gem 'rubocop'
-gem 'ostruct'

--- a/lib/mongoid/paranoia/monkey_patches.rb
+++ b/lib/mongoid/paranoia/monkey_patches.rb
@@ -19,36 +19,6 @@ Mongoid::Document.include Mongoid::Paranoia::Document
 
 module Mongoid
   module Association
-    module Nested
-      class Many
-        # Destroy the child document, needs to do some checking for embedded
-        # relations and delay the destroy in case parent validation fails.
-        #
-        # @api private
-        #
-        # @example Destroy the child.
-        #   builder.destroy(parent, relation, doc)
-        #
-        # @param [ Document ] parent The parent document.
-        # @param [ Proxy ] relation The relation proxy.
-        # @param [ Document ] doc The doc to destroy.
-        #
-        # @since 3.0.10
-        def destroy(parent, relation, doc)
-          doc.flagged_for_destroy = true
-          if !doc.embedded? || parent.new_record?
-            destroy_document(relation, doc)
-          else
-            parent.flagged_destroys.push(-> { destroy_document(relation, doc) })
-          end
-        end
-      end
-    end
-  end
-end
-
-module Mongoid
-  module Association
     module Embedded
       class EmbedsMany
         class Proxy < Association::Many

--- a/lib/mongoid/paranoia/monkey_patches.rb
+++ b/lib/mongoid/paranoia/monkey_patches.rb
@@ -12,10 +12,33 @@ module Mongoid
         class_attribute :paranoid
       end
     end
+
+    # Skip paranoid docs flagged for destruction when checking whether a
+    # candidate is already related, so they do not block a new sibling with
+    # the same `==` key during a destroy-and-re-add nested attributes update.
+    # Non-paranoid candidates fall through to stock Mongoid behavior via
+    # `super`, so any future upstream fix is inherited automatically.
+    module EmbedsManyProxyExtensions
+      private
+
+      # @example Check if a document is already related.
+      #   relation.send(:object_already_related?, document)
+      #
+      # @param [ Document ] document The candidate document to check.
+      #
+      # @return [ true, false ] If a non-flagged sibling matches.
+      def object_already_related?(document)
+        return super unless document.paranoid?
+        # rubocop:disable Style/CaseEquality -- matches upstream Mongoid's dedup check
+        _target.any? {|existing| existing._id && !existing.flagged_for_destroy? && existing === document }
+        # rubocop:enable Style/CaseEquality
+      end
+    end
   end
 end
 
 Mongoid::Document.include Mongoid::Paranoia::Document
+Mongoid::Association::Embedded::EmbedsMany::Proxy.prepend(Mongoid::Paranoia::EmbedsManyProxyExtensions)
 
 module Mongoid
   module Association

--- a/lib/mongoid/paranoia/monkey_patches.rb
+++ b/lib/mongoid/paranoia/monkey_patches.rb
@@ -36,7 +36,7 @@ module Mongoid
         # @since 3.0.10
         def destroy(parent, relation, doc)
           doc.flagged_for_destroy = true
-          if !doc.embedded? || parent.new_record? || doc.paranoid?
+          if !doc.embedded? || parent.new_record?
             destroy_document(relation, doc)
           else
             parent.flagged_destroys.push(-> { destroy_document(relation, doc) })

--- a/spec/mongoid/nested_attributes_spec.rb
+++ b/spec/mongoid/nested_attributes_spec.rb
@@ -68,10 +68,6 @@ describe Mongoid::Attributes::Nested do
                             }
                           end
 
-                          # The destroy is deferred until parent save (matching stock
-                          # Mongoid behavior for non-paranoid embedded docs). Pre-save the
-                          # in-memory collection still contains the doc flagged for destruction.
-
                           it "flags the marked document for destruction" do
                             expect(phone_one.flagged_for_destroy?).to be true
                           end
@@ -93,9 +89,7 @@ describe Mongoid::Attributes::Nested do
                             expect(persisted.paranoid_phones.last.number).to eq("4")
                           end
 
-                          it "counts only persisted (non-pending) docs" do
-                            # phone_one and phone_two are persisted; the new phone is not
-                            # persisted until parent save runs.
+                          it "counts only persisted documents" do
                             expect(persisted.paranoid_phones.count).to eq(2)
                           end
 
@@ -117,59 +111,104 @@ describe Mongoid::Attributes::Nested do
                               expect(persisted.reload.paranoid_phones.last.number).to eq("4")
                             end
                           end
+
+                          context "when saving the parent fails validation" do
+
+                            before do
+                              Person.class_eval { validate { errors.add(:base, "nope") } }
+                              persisted.save
+                            end
+
+                            after do
+                              Person._validate_callbacks.clear
+                            end
+
+                            it "does not soft-delete the marked document" do
+                              expect(phone_one.reload.deleted_at).to be_nil
+                            end
+
+                            it "leaves the persisted collection intact" do
+                              expect(persisted.reload.paranoid_phones.count).to eq(2)
+                            end
+
+                            it "does not persist the new document" do
+                              expect(persisted.reload.paranoid_phones.where(number: "4")).to be_empty
+                            end
+                          end
                         end
                       end
                     end
                   end
-                end
 
-                context "regression: deferred destroy on parent validation failure" do
-                  # Before the fix, assigning _destroy: true on a paranoid embedded doc
-                  # immediately persisted a soft-delete via update_one, regardless of
-                  # whether the parent's subsequent save succeeded. This left orphaned
-                  # soft-deletes if the parent was rejected by validations or if save
-                  # was never called (e.g. a read-only preview endpoint).
+                  context "when the child overrides equality" do
 
-                  before(:all) do
-                    Person.send(:undef_method, :paranoid_phones_attributes=)
-                    Person.accepts_nested_attributes_for :paranoid_phones, allow_destroy: true
-                  end
-
-                  after(:all) do
-                    Person.send(:undef_method, :paranoid_phones_attributes=)
-                    Person.accepts_nested_attributes_for :paranoid_phones
-                  end
-
-                  let!(:persisted) do
-                    Person.create do |p|
-                      p.paranoid_phones << ParanoidPhone.new(number: "1")
+                    before(:all) do
+                      ParanoidPhone.class_eval do
+                        def ==(other)
+                          other.is_a?(self.class) && number == other.number
+                        end
+                        alias_method :eql?, :==
+                      end
                     end
-                  end
-                  let(:phone) { persisted.paranoid_phones.first }
 
-                  it "does not soft-delete when assign_attributes is not followed by save" do
-                    persisted.assign_attributes(paranoid_phones_attributes: [{ id: phone.id, _destroy: "1" }])
-                    expect(phone.reload.deleted_at).to be_nil
-                    expect(persisted.reload.paranoid_phones.count).to eq(1)
-                  end
+                    after(:all) do
+                      ParanoidPhone.send(:remove_method, :==)
+                      ParanoidPhone.send(:remove_method, :eql?)
+                    end
 
-                  it "does not soft-delete when the parent save fails validation" do
-                    invalid = Class.new(StandardError)
-                    Person.validate { errors.add(:base, "nope") if @reject_save }
-                    persisted.instance_variable_set(:@reject_save, true)
-                    expect {
-                      persisted.update_attributes!(paranoid_phones_attributes: [{ id: phone.id, _destroy: "1" }])
-                    }.to raise_error(Mongoid::Errors::Validations)
-                    expect(phone.reload.deleted_at).to be_nil
-                    expect(persisted.reload.paranoid_phones.count).to eq(1)
-                    Person._validate_callbacks.clear
-                  end
+                    context "when the parent is persisted" do
 
-                  it "soft-deletes when the parent save succeeds" do
-                    persisted.update_attributes!(paranoid_phones_attributes: [{ id: phone.id, _destroy: "1" }])
-                    expect(phone.reload.deleted_at).not_to be_nil
-                    expect(persisted.reload.paranoid_phones.count).to eq(0)
-                    expect(persisted.reload.paranoid_phones.unscoped.count).to eq(1)
+                      let!(:persisted) do
+                        Person.create do |p|
+                          p.paranoid_phones << [ phone_one, phone_two ]
+                        end
+                      end
+
+                      context "when destroying then re-adding a sibling with the same key" do
+
+                        before do
+                          persisted.paranoid_phones_attributes =
+                            {
+                              "bar" => { "id" => phone_one.id, "_destroy" => "1" },
+                              "baz" => { "number" => "1" }
+                            }
+                        end
+
+                        it "keeps the new sibling in the relation" do
+                          fresh = persisted.paranoid_phones.send(:_target).reject(&:flagged_for_destroy?)
+                          expect(fresh.map(&:number)).to include("1")
+                        end
+
+                        context "when saving the parent" do
+
+                          before do
+                            persisted.save
+                          end
+
+                          it "soft-deletes the original sibling" do
+                            expect(phone_one.reload.deleted_at).not_to be_nil
+                          end
+
+                          it "persists the new sibling" do
+                            reloaded = persisted.reload.paranoid_phones
+                            expect(reloaded.map(&:number)).to contain_exactly("1", "2")
+                            expect(reloaded.where(number: "1").first.id).not_to eq(phone_one.id)
+                          end
+                        end
+                      end
+
+                      context "when pushing a duplicate of a live sibling" do
+
+                        before do
+                          persisted.paranoid_phones.push(ParanoidPhone.new(number: "1"))
+                        end
+
+                        it "does not add the duplicate to the relation" do
+                          target = persisted.paranoid_phones.send(:_target)
+                          expect(target.count {|p| p.number == "1" }).to eq(1)
+                        end
+                      end
+                    end
                   end
                 end
 

--- a/spec/mongoid/nested_attributes_spec.rb
+++ b/spec/mongoid/nested_attributes_spec.rb
@@ -68,24 +68,35 @@ describe Mongoid::Attributes::Nested do
                             }
                           end
 
-                          it "removes the first document from the relation" do
-                            expect(persisted.paranoid_phones.size).to eq(2)
+                          # The destroy is deferred until parent save (matching stock
+                          # Mongoid behavior for non-paranoid embedded docs). Pre-save the
+                          # in-memory collection still contains the doc flagged for destruction.
+
+                          it "flags the marked document for destruction" do
+                            expect(phone_one.flagged_for_destroy?).to be true
                           end
 
-                          it "does not delete the unmarked document" do
-                            expect(persisted.paranoid_phones.first.number).to eq("3")
+                          it "does not soft-delete the marked document until save" do
+                            expect(phone_one).not_to be_destroyed
+                            expect(phone_one.reload.deleted_at).to be_nil
+                          end
+
+                          it "keeps the marked document in the relation pending save" do
+                            expect(persisted.paranoid_phones.size).to eq(3)
+                          end
+
+                          it "applies the update to the unmarked document" do
+                            expect(persisted.paranoid_phones.find(phone_two.id).number).to eq("3")
                           end
 
                           it "adds the new document to the relation" do
                             expect(persisted.paranoid_phones.last.number).to eq("4")
                           end
 
-                          it "has the proper persisted count" do
-                            expect(persisted.paranoid_phones.count).to eq(1)
-                          end
-
-                          it "soft deletes the removed document" do
-                            expect(phone_one).to be_destroyed
+                          it "counts only persisted (non-pending) docs" do
+                            # phone_one and phone_two are persisted; the new phone is not
+                            # persisted until parent save runs.
+                            expect(persisted.paranoid_phones.count).to eq(2)
                           end
 
                           context "when saving the parent" do
@@ -109,6 +120,56 @@ describe Mongoid::Attributes::Nested do
                         end
                       end
                     end
+                  end
+                end
+
+                context "regression: deferred destroy on parent validation failure" do
+                  # Before the fix, assigning _destroy: true on a paranoid embedded doc
+                  # immediately persisted a soft-delete via update_one, regardless of
+                  # whether the parent's subsequent save succeeded. This left orphaned
+                  # soft-deletes if the parent was rejected by validations or if save
+                  # was never called (e.g. a read-only preview endpoint).
+
+                  before(:all) do
+                    Person.send(:undef_method, :paranoid_phones_attributes=)
+                    Person.accepts_nested_attributes_for :paranoid_phones, allow_destroy: true
+                  end
+
+                  after(:all) do
+                    Person.send(:undef_method, :paranoid_phones_attributes=)
+                    Person.accepts_nested_attributes_for :paranoid_phones
+                  end
+
+                  let!(:persisted) do
+                    Person.create do |p|
+                      p.paranoid_phones << ParanoidPhone.new(number: "1")
+                    end
+                  end
+                  let(:phone) { persisted.paranoid_phones.first }
+
+                  it "does not soft-delete when assign_attributes is not followed by save" do
+                    persisted.assign_attributes(paranoid_phones_attributes: [{ id: phone.id, _destroy: "1" }])
+                    expect(phone.reload.deleted_at).to be_nil
+                    expect(persisted.reload.paranoid_phones.count).to eq(1)
+                  end
+
+                  it "does not soft-delete when the parent save fails validation" do
+                    invalid = Class.new(StandardError)
+                    Person.validate { errors.add(:base, "nope") if @reject_save }
+                    persisted.instance_variable_set(:@reject_save, true)
+                    expect {
+                      persisted.update_attributes!(paranoid_phones_attributes: [{ id: phone.id, _destroy: "1" }])
+                    }.to raise_error(Mongoid::Errors::Validations)
+                    expect(phone.reload.deleted_at).to be_nil
+                    expect(persisted.reload.paranoid_phones.count).to eq(1)
+                    Person._validate_callbacks.clear
+                  end
+
+                  it "soft-deletes when the parent save succeeds" do
+                    persisted.update_attributes!(paranoid_phones_attributes: [{ id: phone.id, _destroy: "1" }])
+                    expect(phone.reload.deleted_at).not_to be_nil
+                    expect(persisted.reload.paranoid_phones.count).to eq(0)
+                    expect(persisted.reload.paranoid_phones.unscoped.count).to eq(1)
                   end
                 end
 


### PR DESCRIPTION
Currently paranoid nested attributes call destroy_document right when the nested attributes are assigned, regardless of validations on the parent record, or `.save` being called at all.

This PR fixes it.

Here is a bit of git archeology from Claude on this issue:

```
  Oct 24 2012 — mongoid dc0908953 / dfe40a3ac (3.0.10), Durran Jordan:

  ▎ Fix removal on embedded document via nested attrs.
  ▎ Previously, embedded documents would get removed from the relation on a nested attributes delete immediately, which would cause issues if the parent document validation failed. Now these removals are delayed until the parent passes
  ▎ validation and goes to persist.

  This commit is fixing the exact same bug we just fixed — but only for non-paranoid embedded docs. Durran intentionally kept paranoid docs on the immediate-destroy path by adding || doc.paranoid? to the condition. The most likely reason:
   the deferred path eventually calls relation.delete(doc) → add_atomic_pull(doc), which would do a hard $pull and defeat paranoia entirely. Keeping paranoid on the immediate path preserved soft-delete semantics, but at the cost of the
  validation-failure leak.

  Oct 29 2012 — mongoid a9a65525d (next release), same author:

  ▎ Remove Mongoid::Paranoia. [ close #2433 ]

  Five days later, when Durran ripped built-in Paranoia out of upstream, he also removed the || doc.paranoid? short-circuit. The diff is literally the change we just made to the gem:

  - if !doc.embedded? || parent.new_record? || doc.paranoid?
  + if !doc.embedded? || parent.new_record?

  He removed it because there were no longer any paranoid docs to need it — not because he had figured out a way to make paranoid + deferred-destroy work together. The combined intent (defer + preserve soft-delete) was never reconciled in
   upstream Mongoid.

  Feb 2 2013 — mongoid_paranoia "Init" by Josef Šimánek:

  When Josef extracted Paranoia into a standalone gem, he copied the patches verbatim from Mongoid 3.0.10 (the version with the || doc.paranoid? short-circuit). The bug came along for the ride and has lived in every version of
  mongoid_paranoia since.

  Why our fix is safe

  Our fix combines what neither of the original commits did:

  - Remove || doc.paranoid? from Many#destroy (Durran's intent in a9a65525d, generalized) → defers paranoid destroys to flagged_destroys.
  - Keep the EmbedsMany::Proxy#delete patch's _assigning? && paranoid? branch that calls doc.destroy(suppress: true) (Durran's original concern in dc0908953) → when the deferred lambda fires inside process_flagged_destroys's _assigning do
   ... end wrap, paranoia's soft-delete still runs.

  The two patches together preserve paranoia's soft-delete semantics AND defer the write until after validation. That's the missing combination Durran never got to ship before he removed Paranoia entirely.
```